### PR TITLE
Update servicectl

### DIFF
--- a/servicectl
+++ b/servicectl
@@ -13,7 +13,7 @@ DIR=$(dirname $(readlink -f $0))
 SERVICECTL_ENABLED_PATH="$DIR/enabled/"
 
 # Check is root
-if [ $EUID -ne 0 ]; then
+if [ "$(id -u)" -ne 0 ]; then
   echo "You must run as root user" 2>&1
   exit 1
 fi


### PR DESCRIPTION
fixing error user's ID
and make sure changed shebang sh to bash

/usr/local/bin/servicectl: 16: [: -ne: unexpected operator
/usr/local/bin/servicectl: 23: Syntax error: "(" unexpected

tested on Ubuntu 22.04 on a Linux deploy